### PR TITLE
creates/assigns dns alias for opentutor beanstalk env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # terraform-opentutor-aws-beanstalk
 
-Terraform module creates infrasture for an opentutor Elastic Beanstalk deployment on AWS
+Terraform module creates infrastructure for an opentutor Elastic Beanstalk deployment on AWS
 
 TODO:
 
  - [x] creates/destroys beanstalk infra that runs app
  - [ ] ensure all features working (home page)
  - [ ] ensure all features working (online training)
- - [ ] stores tf state in an S3 bucket
- - [ ] configurable for CNAME, e.g. opentutor.org
- - [ ] SSL support (https://opentutor.org)
+ - [x] stores tf state in an S3 bucket
+ - [x] configurable for CNAME, e.g. opentutor.org
+ - [x] SSL support (https://opentutor.org)
  - [ ] instances use shared EFS mount for online-trained models
  - [ ] functions as a terraform module, where actual deployments just include the module

--- a/module_main.tf
+++ b/module_main.tf
@@ -67,6 +67,8 @@ module "elastic_beanstalk_environment" {
   elastic_beanstalk_application_name = module.elastic_beanstalk_application.elastic_beanstalk_application_name
   environment_type                   = var.environment_type
   loadbalancer_type                  = var.loadbalancer_type
+  loadbalancer_certificate_arn       = data.aws_acm_certificate.issued.arn
+  loadbalancer_ssl_policy            = "ELBSecurityPolicy-TLS-1-2-2017-01"
   elb_scheme                         = var.elb_scheme
   tier                               = var.tier
   version_label                      = var.version_label
@@ -121,7 +123,6 @@ data "aws_iam_policy_document" "minimal_s3_permissions" {
   }
 }
 
-
 # public cname/alias for the site
 # pull in the dns zone
 data "aws_route53_zone" "site_dns" {
@@ -137,14 +138,14 @@ data "aws_acm_certificate" "issued" {
 
 # create dns record of type "A"
 resource "aws_route53_record" "site_alias" {
-  zone_id         = "${data.aws_route53_zone.site_dns.zone_id}"
-  name            = "${data.aws_route53_zone.site_dns.name}"
+  zone_id         = data.aws_route53_zone.site_dns.zone_id
+  name            = data.aws_route53_zone.site_dns.name
   type            = "A"
   allow_overwrite = true
   # create alias (required: name, zone_id)
   alias {
-    name                   = "${module.elastic_beanstalk_environment.endpoint}"
-    zone_id                = "${data.aws_elastic_beanstalk_hosted_zone.current.id}"
+    name                   = module.elastic_beanstalk_environment.endpoint
+    zone_id                = data.aws_elastic_beanstalk_hosted_zone.current.id
     evaluate_target_health = true
   }
 }

--- a/module_main.tf
+++ b/module_main.tf
@@ -137,11 +137,6 @@ resource "aws_route53_record" "site_alias" {
   allow_overwrite = true
   # create alias (required: name, zone_id)
   alias {
-
-    # CURRENT PROBLEM: 
-    # module.elastic_beanstalk_environment.hostname
-    # is an output and doesn't seem to be populated 
-    # when this applies.
     name                   = "${module.elastic_beanstalk_environment.endpoint}"
     zone_id                = "${data.aws_elastic_beanstalk_hosted_zone.current.id}"
     evaluate_target_health = true

--- a/module_main.tf
+++ b/module_main.tf
@@ -125,7 +125,13 @@ data "aws_iam_policy_document" "minimal_s3_permissions" {
 # public cname/alias for the site
 # pull in the dns zone
 data "aws_route53_zone" "site_dns" {
-  name = "opentutor.info."
+  name = var.aws_route53_zone_name
+}
+
+# Find a certificate that is issued
+data "aws_acm_certificate" "issued" {
+  domain   = var.aws_acm_certificate_domain
+  statuses = ["ISSUED"]
 }
 
 

--- a/module_main.tf
+++ b/module_main.tf
@@ -128,6 +128,7 @@ data "aws_route53_zone" "site_dns" {
   name = "opentutor.info."
 }
 
+
 # create dns record of type "A"
 resource "aws_route53_record" "site_alias" {
   zone_id         = "${data.aws_route53_zone.site_dns.zone_id}"
@@ -141,7 +142,7 @@ resource "aws_route53_record" "site_alias" {
     # module.elastic_beanstalk_environment.hostname
     # is an output and doesn't seem to be populated 
     # when this applies.
-    name                   = "${module.elastic_beanstalk_environment.hostname}"
+    name                   = "${module.elastic_beanstalk_environment.endpoint}"
     zone_id                = "${data.aws_elastic_beanstalk_hosted_zone.current.id}"
     evaluate_target_health = true
   }

--- a/module_variables.tf
+++ b/module_variables.tf
@@ -203,3 +203,13 @@ variable "env_vars" {
   default     = {}
   description = "Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env_vars = { DB_USER = 'admin' DB_PASS = 'xxxxxx' }"
 }
+
+variable "aws_acm_certificate_domain" {
+  type        = string
+  description = "domain name to find ssl certificate"
+}
+
+variable "aws_route53_zone_name" {
+  type        = string
+  description = "name to find aws route53 zone, e.g. opentutor.info."
+}

--- a/s3_state_main.tf
+++ b/s3_state_main.tf
@@ -38,14 +38,9 @@ resource "aws_dynamodb_table" "terraform_locks" {
 terraform {
   # unfortunately, vars not allowed in terraform blocks...
   backend "s3" {
-    # Replace this with your bucket name!
-    # bucket         = var.state_bucket_name
     bucket         = "opentutor-s3-state"
     key            = "global/s3/terraform.tfstate"
-    # region         = var.region
     region         = "us-east-1"
-    # Replace this with your DynamoDB table name!
-    # dynamodb_table = "${var.state_bucket_name}-locks"
     dynamodb_table = "opentutor-s3-state-locks"
     encrypt        = true
   }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -96,3 +96,7 @@ additional_settings = [
 #   "DB_PASSWORD"     = "zzzzzzzzzzzzzzzzzzz"
 #   "ANOTHER_ENV_VAR" = "123456789"
 # 
+
+aws_acm_certificate_domain = "opentutor.info"
+
+aws_route53_zone_name = "opentutor.info."

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = "~> 2.7"
     null = "~> 2.0"
   }
 }


### PR DESCRIPTION
This PR doesn't add anything successfully yet, but...

## Goals

- [ ] creates and assigns a dns alias for the Beanstalk environment, e.g. `opentutor.info` => `prod-opentutor.elasticbeanstalk.us-east-1.aws.com`
- [ ] ideally applies a static name to the Beastalk environment, e.g. `prod-opentutor.elasticbeanstalk.us-east-1.aws.com` instead of  default generated `some-uuid-1234.elasticbeanstalk.us-east-1.aws.com`
- [ ] use conditional logic to make having/assigning the alias is optional for deployments

## Followup PR Goals

- [ ] find and assign an AWS SSL certificate to the Beanstalk env (presumably created manually, outside of terraform)
- [ ] configure Beanstalk env to use SSL (terminated at load balancer for now)